### PR TITLE
Delegate LiveView handle_params/3

### DIFF
--- a/lib/phoenix_playground/endpoint.ex
+++ b/lib/phoenix_playground/endpoint.ex
@@ -27,6 +27,8 @@ defmodule PhoenixPlayground.Endpoint do
   # TODO:
   # plug Phoenix.Ecto.CheckRepoStatus, otp_app: :phoenix_playground
 
+  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],

--- a/lib/phoenix_playground/router.ex
+++ b/lib/phoenix_playground/router.ex
@@ -112,6 +112,13 @@ defmodule PhoenixPlayground.Router do
     end
 
     @impl true
+    def handle_params(unsigned_params, uri, socket) do
+      if function_exported?(module(), :handle_params, 3),
+        do: module().handle_params(unsigned_params, uri, socket),
+        else: {:noreply, socket}
+    end
+
+    @impl true
     def handle_event(event, params, socket) do
       module().handle_event(event, params, socket)
     end

--- a/lib/phoenix_playground/router.ex
+++ b/lib/phoenix_playground/router.ex
@@ -113,9 +113,11 @@ defmodule PhoenixPlayground.Router do
 
     @impl true
     def handle_params(unsigned_params, uri, socket) do
-      if function_exported?(module(), :handle_params, 3),
-        do: module().handle_params(unsigned_params, uri, socket),
-        else: {:noreply, socket}
+      if function_exported?(module(), :handle_params, 3) do
+        module().handle_params(unsigned_params, uri, socket)
+      else
+        {:noreply, socket}
+      end
     end
 
     @impl true


### PR DESCRIPTION
I am toying with the Phoenix Playground and finding it very useful so far. 

I was implementing the `handle_params/3` callback in my LiveView and noticed that it was not being called. After a quick inspection it turns out that the `DelegateLive` module is not delegating that callback.

This pull request implements that delegation so the `handle_params/3` will be called if the delegated LiveView implements it. Since the `DelegateLive` implements that callback it will always be called after `mount` so, if the delegated LiveView does not implement it, it will not be called.