### PR TITLE
Add title tag to layout head

### DIFF
--- a/lib/phoenix_playground/layouts.ex
+++ b/lib/phoenix_playground/layouts.ex
@@ -10,6 +10,7 @@ defmodule PhoenixPlayground.Layouts do
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Phoenix Playground</title>
       </head>
       <body>
         <%= @inner_content %>


### PR DESCRIPTION
Hey, thanks for such a great tool!

I'm testing out a use case for this in which I'm running [a11y_audit](https://hexdocs.pm/a11y_audit/readme.html) on a Phoenix component library which doesn't hold a phoenix application -- so phoenix playground is proving very helpful.

Anyway, a `<head>` missing a `<title>` tag is considered a critical a11y error according to the audit, so this is a quick fix for that.

Cheers