### PR TITLE
Add support for hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See more examples below:
   * [`examples/demo_controller.exs`]
   * [`examples/demo_controller_test.exs`]
   * [`examples/demo_plug.exs`]
+  * [`examples/demo_hook.exs`]
 
 ## License
 
@@ -82,3 +83,4 @@ limitations under the License.
 [`examples/demo_controller.exs`]: examples/demo_controller.exs
 [`examples/demo_controller_test.exs`]: examples/demo_controller_test.exs
 [`examples/demo_plug.exs`]: examples/demo_plug.exs
+[`examples/demo_hook.exs`]: examples/demo_hook.exs

--- a/examples/demo_hook.exs
+++ b/examples/demo_hook.exs
@@ -1,0 +1,33 @@
+#!/usr/bin/env elixir
+Mix.install([
+  {:phoenix_playground, "~> 0.1.3"}
+])
+
+defmodule DemoHook do
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <span id="hook" phx-hook="MyHook">LiveView</span>
+
+    <script>
+    window.hooks.MyHook = {
+      mounted() {
+        this.el.innerHTML += " rocks";
+        setInterval(() => this.el.innerHTML += "!", 1000);
+      }
+    }
+    </script>
+
+    <style type="text/css">
+      body { padding: 1em; }
+    </style>
+    """
+  end
+end
+
+PhoenixPlayground.start(live: DemoHook)

--- a/lib/phoenix_playground/layouts.ex
+++ b/lib/phoenix_playground/layouts.ex
@@ -23,7 +23,10 @@ defmodule PhoenixPlayground.Layouts do
     <script src="/assets/phoenix/phoenix.js"></script>
     <script src="/assets/phoenix_live_view/phoenix_live_view.js"></script>
     <script>
-      let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket)
+      // Set a global hooks object to be used by the LiveSocket,
+      // this allows hooks to be defined directly in LiveView templates.
+      window.hooks = {}
+      let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket, { hooks })
       liveSocket.connect()
 
       window.addEventListener("phx:live_reload:attached", ({detail: reloader}) => {


### PR DESCRIPTION
Implementation/Proposal for #6

The LiveSocket only connects [when the document loading is complete](https://github.com/phoenixframework/phoenix_live_view/blob/88474ac2cee67e0a431f7f723fa1bccc6b7627f6/assets/js/phoenix_live_view/live_socket.js#L228). By using a global object and adding a hook to it during the first render, the hook will be in place before the connect() runs, ensuring it works as expected.
