### PR TITLE
Allow endpoint_options to be passed

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
 # Used by "mix format"
 [
   import_deps: [:phoenix],
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,examples,lib,test}/**/*.{ex,exs}"]
 ]

--- a/examples/demo_controller.exs
+++ b/examples/demo_controller.exs
@@ -1,6 +1,6 @@
 #!/usr/bin/env elixir
 Mix.install([
-  {:phoenix_playground, path: Path.expand("..", __DIR__)}
+  {:phoenix_playground, "~> 0.1.3"}
 ])
 
 defmodule DemoController do
@@ -32,9 +32,4 @@ defmodule DemoController do
   end
 end
 
-PhoenixPlayground.start(
-  controller: DemoController,
-  endpoint_options: [
-    secret_key_base: "b8X+FHhV/h4N3mFRcwtGmKmTIJkl7acxJyTujEWevtfmH7T+v3P9tb+H+K1JpJlj"
-  ]
-)
+PhoenixPlayground.start(controller: DemoController)

--- a/examples/demo_controller.exs
+++ b/examples/demo_controller.exs
@@ -1,6 +1,6 @@
 #!/usr/bin/env elixir
 Mix.install([
-  {:phoenix_playground, "~> 0.1.3"}
+  {:phoenix_playground, path: Path.expand("..", __DIR__)}
 ])
 
 defmodule DemoController do
@@ -32,4 +32,9 @@ defmodule DemoController do
   end
 end
 
-PhoenixPlayground.start(controller: DemoController)
+PhoenixPlayground.start(
+  controller: DemoController,
+  endpoint_options: [
+    secret_key_base: "b8X+FHhV/h4N3mFRcwtGmKmTIJkl7acxJyTujEWevtfmH7T+v3P9tb+H+K1JpJlj"
+  ]
+)

--- a/lib/phoenix_playground.ex
+++ b/lib/phoenix_playground.ex
@@ -85,6 +85,9 @@ defmodule PhoenixPlayground do
 
         {:ok, pid}
 
+      {:error, {{:EXIT, {exception, _trace}}, _child_info}} ->
+        raise exception
+
       other ->
         other
     end

--- a/lib/phoenix_playground.ex
+++ b/lib/phoenix_playground.ex
@@ -37,6 +37,8 @@ defmodule PhoenixPlayground do
 
     * `:port` - port to listen on, defaults to: `4000`.
 
+    * `:endpoint_options` - additional Phoenix endpoint options, defaults to `[]`.
+
     * `:open_browser` - whether to open the browser on start, defaults to `true`.
 
     * `:child_specs` - child specs to run in Phoenix Playground supervision tree. The playground

--- a/lib/phoenix_playground.ex
+++ b/lib/phoenix_playground.ex
@@ -128,11 +128,12 @@ defmodule PhoenixPlayground do
       Keyword.validate!(options, [
         :live,
         :controller,
-        :plug,
         :file,
+        :plug,
         child_specs: [],
         port: 4000,
-        open_browser: true
+        open_browser: true,
+        endpoint_options: []
       ])
 
     child_specs = Keyword.fetch!(options, :child_specs)
@@ -208,6 +209,7 @@ defmodule PhoenixPlayground do
           ] ++ live_reload_options,
         phoenix_playground: Keyword.take(options, [:live, :controller, :plug])
       ]
+      |> Keyword.merge(Keyword.get(options, :endpoint_options, []))
 
     children =
       child_specs ++


### PR DESCRIPTION
Running the `demo_controller.exs` example crashes locally with: 

```
[error] ** (ArgumentError) cookie store expects conn.secret_key_base to be at least 64 bytes
```

After looking at the code, I found out that the `:secret_key_base` is randomly generated at startup using the hostname. However, due to the very short hostname (3 chars), it crashed locally. I decided to implement `:endpoint_options` instead of just `:secret_key_base` because, in the playground where I was experimenting, I also needed `:check_origin` to be set dynamically to a NGROK domain.

I also ensured that the examples are always formatted and that crashes are not silenced. I can split these into separate PRs if desired.

What are your thoughts?