### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ limitations under the License.
 [`examples/demo_controller.exs`]: examples/demo_controller.exs
 [`examples/demo_controller_test.exs`]: examples/demo_controller_test.exs
 [`examples/demo_plug.exs`]: examples/demo_plug.exs
-[`examples/demo_hook.exs`]: examples/demo_hook.exs
+[`examples/demo_hooks.exs`]: examples/demo_hooks.exs


### PR DESCRIPTION
The changes tweak the `demo_hooks` url which is off after `demo_hook` to `demo_hooks` rename: https://github.com/phoenix-playground/phoenix_playground/commit/bf09a9f65a92dd013cb8be2bd73c92fab7d858ed